### PR TITLE
minor tweak to composer css

### DIFF
--- a/css/app.styl
+++ b/css/app.styl
@@ -216,7 +216,7 @@ input
   font-size: FONT_SIZE
   position: absolute
   bottom: 0
-  width: calc(100% - 20px)
+  width: calc(100% - 25px)
   padding: SPACING_SIZE
   margin: SPACING_SIZE
   border: solid 3px GRAY_LIGHT


### PR DESCRIPTION
In Linux, the composer box overlaps the scroll bar a bit:
![image](https://cloud.githubusercontent.com/assets/360233/7362286/4b86bde8-ed2c-11e4-940b-e37069bde525.png)

This change makes it not do that:
![clipboard03](https://cloud.githubusercontent.com/assets/360233/7362299/7d79408c-ed2c-11e4-80d3-70e9532d673f.jpg)
