### PR TITLE
Improve autocomplete

### DIFF
--- a/lib/elements/composer.js
+++ b/lib/elements/composer.js
@@ -22,7 +22,7 @@ Composer.prototype.render = function () {
     onkeydown: function (e) {
       if (e.keyCode === 9 && self.autocompleting !== false) {
         e.preventDefault()
-        this.value = this.value + self.autocompleting
+        this.value = self.autocompleting
         self.autocompleting = false
       }
     },
@@ -47,10 +47,11 @@ Composer.prototype.autocomplete = function (text) {
     return
   }
   for (var i = 0; i < this.autocompletes.length; i++) {
-    var val = this.autocompletes[i]
-    if (val.indexOf(text) !== -1) {
+    var val = this.autocompletes[i].toLowerCase()
+    var lowerCaseText = text.toLowerCase()
+    if (val.indexOf(lowerCaseText) === 0) {
       if (this.autocompletes[i] === text) this.autocompleting = false
-      else this.autocompleting = this.autocompletes[i].slice(text.length) + ': '
+      else this.autocompleting = this.autocompletes[i] + ': '
       return
     }
   }


### PR DESCRIPTION
Some improvements to autocomplete:
- convert source and candidate to lower case before checking for matches
- change to match the beginning of the string only
- if matched, replace the whole string with an appropriately cased string

#### Demo:
![anim](https://cloud.githubusercontent.com/assets/360233/7364715/343388ba-ed4f-11e4-8cb0-fe1dcdf38354.gif)
