### PR TITLE
Prevent tabbing away from composer if text is present

### DIFF
--- a/lib/elements/composer.js
+++ b/lib/elements/composer.js
@@ -20,10 +20,12 @@ Composer.prototype.render = function () {
     placeholder: 'Send a message...',
     autofocus: true,
     onkeydown: function (e) {
-      if (e.keyCode === 9 && self.autocompleting !== false) {
-        e.preventDefault()
-        this.value = self.autocompleting
-        self.autocompleting = false
+      if (e.keyCode === 9) {
+        if (this.value.length > 0) e.preventDefault()
+        if (self.autocompleting !== false) {
+          this.value = self.autocompleting
+          self.autocompleting = false
+        }
       }
     },
     onkeyup: function (e) {


### PR DESCRIPTION
This gives a bit nicer experience when jamming on the tab key for autocomplete while still allowing users to tab to another element when the composer is empty.