### PR TITLE
Use twemoji so emoji work for all

### DIFF
--- a/css/app.styl
+++ b/css/app.styl
@@ -263,3 +263,8 @@ textarea.composer
   position: absolute
   width: calc(100% - 25px)
 
+img.emoji
+  height: 1.2em
+  width: 1.2em
+  margin: 0 .05em 0 .1em
+  vertical-align: -0.1em

--- a/lib/rich-message.js
+++ b/lib/rich-message.js
@@ -6,6 +6,7 @@ var ghlink = require('ghlink')
 var higlight = require('highlight.js')
 var htmlToVDom = require('html-to-vdom')
 var MarkdownIt = require('markdown-it')
+var twemoji = require('twemoji')
 var util = require('./util.js')
 var VNode = require('virtual-dom/vnode/vnode')
 var VText = require('virtual-dom/vnode/vtext')
@@ -26,6 +27,10 @@ var md = new MarkdownIt({
     return '' // use external default escaping
   }
 }).use(emoji)
+
+md.renderer.rules.emoji = function (token, index) {
+  return twemoji.parse(token[index].content)
+}
 
 var convertHTML = htmlToVDom({
   VNode: VNode,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "single-line-log": "^0.4.1",
     "subleveldown": "^2.0.0",
     "through2": "^0.6.5",
+    "twemoji": "^1.4.1",
     "virtual-dom": "^2.0.1",
     "webrtc-swarm": "^1.2.0"
   },


### PR DESCRIPTION
So `markdown-it-emoji` inserts unicode emoji which do not render on some platforms like Linux. This PR feeds the unicode into twemoji which turns it into an `<img>`.