### PR TITLE
Update dependency (Windows compat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "end-of-stream": "^1.1.0",
     "ghlink": "^0.1.2",
     "ghsign": "^1.2.2",
-    "github-current-user": "^2.3.0",
+    "github-current-user": "^2.4.1",
     "highlight.js": "^8.5.0",
     "html-parser": "^0.8.0",
     "html-to-vdom": "^0.5.5",


### PR DESCRIPTION
github-current-user@2.4.1 incorporates https://github.com/beaugunderson/github-current-user/pull/7 - this makes `friends` work out-of-the-box on my Windows 8 x64 machine