### PR TITLE
don't crash when app.dock api is unavailable

### DIFF
--- a/app.js
+++ b/app.js
@@ -331,6 +331,8 @@ App.prototype.showGitHelp = function () {
 }
 
 App.prototype.setBadge = function (num) {
+  if (!app.dock) return
+
   if (num === false) {
     return app.dock.setBadge('')
   } else if (num == null) {


### PR DESCRIPTION
The dock api is only available on osx and the dock object will be
completely missing on other systems. If it's unavailable don't bother
trying to set the badge