### PR TITLE
change mkdir -p to npm.im/mkdirp (windows compat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,11 @@
     "webrtc-swarm": "^1.2.0"
   },
   "devDependencies": {
-    "node-gyp": "^1.0.3",
-    "electron-prebuilt": "^0.25.1",
     "electron-packager": "^3.1.0",
+    "electron-prebuilt": "^0.25.1",
+    "mkdirp": "^0.5.0",
     "nib": "^1.1.0",
+    "node-gyp": "^1.0.3",
     "standard": "^3.2.1",
     "stylus": "^0.51.0"
   },
@@ -76,12 +77,12 @@
     "url": "https://github.com/moose-team/friends.git"
   },
   "scripts": {
-    "build-css": "mkdir -p dist && stylus -u nib css/app.styl -o dist/ -c",
+    "build-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -c",
     "package": "npm run build-css && electron-packager . Friends --icon=static/Icon.icns",
     "start": "npm run build-css && electron index.js 2>&1 | silence-chromium",
     "test": "standard",
     "watch": "npm run build-css && (npm run watch-css & electron index.js 2>&1 | silence-chromium)",
-    "watch-css": "mkdir -p dist && stylus -u nib css/app.styl -o dist/ -w",
+    "watch-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -w",
     "rebuild-leveldb": "cd node_modules/leveldown && HOME=~/.electron-gyp node-gyp rebuild --target=0.25.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
   }
 }


### PR DESCRIPTION
substack's excellent https://npmjs.com/mkdirp helps npm scripts work crossplatform.

This patch lets `npm start` work on my Windows 8 x64 machine.