### PR TITLE
use set command to override $HOME in rebuild-leveldb script (windows compat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "test": "standard",
     "watch": "npm run build-css && (npm run watch-css & electron index.js 2>&1 | silence-chromium)",
     "watch-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -w",
-    "rebuild-leveldb": "cd node_modules/leveldown && HOME=~/.electron-gyp node-gyp rebuild --target=0.25.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
+    "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.25.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
   }
 }


### PR DESCRIPTION
Windows cmd shell cannot set environment variables with the same syntax as bash; it requires the `set` command. However, `set` is cross platform, so lets use that.

This patch makes `npm run rebuild-leveldb` on my Windows 8 x64 machine, and still works great in bash.