### PR TITLE
add debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ friendsdb/
 node_modules/
 public-keys/
 Friends.app
+debug.log


### PR DESCRIPTION
Apologies in advance if the omission of `debug.log` from `.gitignore` is a feature and not a bug...