### PR TITLE
add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ghlink": "^0.1.2",
     "ghsign": "^1.3.1",
     "github-current-user": "^2.4.1",
+    "highlight.js": "^8.5.0",
     "html-parser": "^0.8.0",
     "html-to-vdom": "^0.5.5",
     "hyperlog": "^3.3.1",


### PR DESCRIPTION
`index.html` references `node_modules/highlight.js/styles/solarized_light.css` for syntax highlighting but `highlight.js` is not in the dependencies in `package.json`. Syntax highlighting works for people who happen to have `highlight.js` lying around in their `node_modules` but is broken for fresh installs. This PR adds it as a dependency to fix this. I think I'm way over-explaining here.