### PR TITLE
Start on splitting web / desktop version

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,6 @@ var inherits = require('inherits')
 var leveldown = require('leveldown')
 var levelup = require('levelup')
 var patch = require('virtual-dom/patch')
-var path = require('path')
 var subleveldown = require('subleveldown')
 
 var richMessage = require('rich-message')

--- a/desktop.js
+++ b/desktop.js
@@ -1,0 +1,62 @@
+module.exports = Desktop
+
+var inherits = require('util').inherits
+var App = require('./app.js')
+
+var remote = require('remote')
+var app = remote.require('app')
+var shell = require('shell')
+var BrowserWindow = remote.require('browser-window')
+var currentWindow = remote.getCurrentWindow()
+
+inherits(Desktop, App)
+
+function Desktop() {
+  if (!(this instanceof Desktop)) return new Desktop()
+  App.call(this, document.body, currentWindow)
+  var self = this
+
+  // clear notifications on focus. TODO: only clear notifications in current channel when we have that
+  currentWindow.on('focus', function () {
+    self.setBadge(false)
+  })
+
+  this.on('showGitHelp', this.showGitHelp.bind(this))
+  this.on('setBadge', this.setBadge.bind(this))
+  this.on('openUrl', function (url) {
+    shell.openExternal(url)
+  })
+}
+
+Desktop.prototype.showGitHelp = function () {
+  var GIT_HELP = 'file://' + path.join(__dirname, 'lib', 'windows', 'git-help.html')
+
+  var gitHelp = new BrowserWindow({
+    width: 600,
+    height: 525,
+    show: false,
+    center: true,
+    resizable: false
+  })
+
+  gitHelp.on('closed', function () {
+    gitHelp = null
+  })
+
+  gitHelp.loadUrl(GIT_HELP)
+
+  gitHelp.show()
+}
+
+Desktop.prototype.setBadge = function (num) {
+  if (!app.dock) return
+
+  if (num === false) {
+    return app.dock.setBadge('')
+  } else if (num == null) {
+    this._notifications++
+  } else {
+    this._notifications = num
+  }
+  app.dock.setBadge(this._notifications.toString())
+}

--- a/desktop.js
+++ b/desktop.js
@@ -3,6 +3,8 @@ module.exports = Desktop
 var inherits = require('util').inherits
 var App = require('./app.js')
 
+var path = require('path')
+
 var remote = require('remote')
 var app = remote.require('app')
 var shell = require('shell')
@@ -11,7 +13,7 @@ var currentWindow = remote.getCurrentWindow()
 
 inherits(Desktop, App)
 
-function Desktop() {
+function Desktop () {
   if (!(this instanceof Desktop)) return new Desktop()
   App.call(this, document.body, currentWindow)
   var self = this

--- a/index.html
+++ b/index.html
@@ -8,16 +8,13 @@
   <audio src="static/startup.ogg" autoplay></audio>
   <script>
   if (typeof require !== 'function') {
-    // If we're not in the electron env
+    // If we are in a web env
     var script = document.createElement('script')
-    script.src = 'app.js'
-    script.onload = function() {
-      new window.App(document.body)
-    }
+    script.src = 'bundle.js'
     document.currentScript.parentNode.insertBefore(script, document.currentScript)
   } else {
     // If we are in the electron env
-    require('./app.js')(document.body)
+    require('./desktop.js')()
   }
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "type": "git",
     "url": "https://github.com/moose-team/friends.git"
   },
-  "browserif": {
+  "browserify": {
     "transforms": ["brfs"]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webrtc-swarm": "^1.2.0"
   },
   "devDependencies": {
+    "beefy": "^2.1.5",
     "electron-packager": "^3.1.0",
     "electron-prebuilt": "^0.25.1",
     "mkdirp": "^0.5.0",
@@ -74,6 +75,9 @@
     "type": "git",
     "url": "https://github.com/moose-team/friends.git"
   },
+  "browserif": {
+    "transforms": ["brfs"]
+  },
   "scripts": {
     "build-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -c",
     "package": "npm run build-css && electron-packager . Friends --icon=static/Icon.icns",
@@ -81,6 +85,7 @@
     "test": "standard",
     "watch": "npm run build-css && (npm run watch-css & electron index.js 2>&1 | silence-chromium)",
     "watch-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -w",
+    "web": "beefy web.js:bundle.js",
     "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.25.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
   }
 }

--- a/web.js
+++ b/web.js
@@ -5,7 +5,7 @@ var App = require('./app.js')
 
 inherits(Web, App)
 
-function Web() {
+function Web () {
   if (!(this instanceof Web)) return new Web()
   App.call(this, document.body)
 
@@ -15,4 +15,4 @@ function Web() {
 }
 
 // Start onload
-new Web()
+Web()

--- a/web.js
+++ b/web.js
@@ -1,0 +1,18 @@
+module.exports = Web
+
+var inherits = require('util').inherits
+var App = require('./app.js')
+
+inherits(Web, App)
+
+function Web() {
+  if (!(this instanceof Web)) return new Web()
+  App.call(this, document.body)
+
+  this.on('openUrl', function (url) {
+    window.open(url)
+  })
+}
+
+// Start onload
+new Web()


### PR DESCRIPTION
This is a start on a web version. It makes `app.js` more platform agnostic and creates a `desktop.js` and `web.js` for the entry points to each version.

Although further work needs to be done to get it running on the web. I'm hitting this error:
```
Error: Cannot find module '/Users/Kyle/Documents/www/friends/node_modules/protocol-buffers/brfs' from '/Users/Kyle/Documents/www/friends'
```
and I imagine a few others are not web friendly. Still looking into solutions around those.

---

`npm run web` will start a server on `localhost:9966`.