### PR TITLE
Move command switch to command.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ var subleveldown = require('subleveldown')
 var richMessage = require('rich-message')
 var Swarm = require('./lib/swarm')
 var util = require('./lib/util')
+var command = require('./lib/command')
 
 var Channels = require('./lib/elements/channels')
 var Composer = require('./lib/elements/composer')
@@ -215,27 +216,7 @@ function App (el, currentWindow) {
     })
   })
 
-  self.on('executeCommand', function (commandStr) {
-    var words = commandStr.split(' ')
-    var command = words[0].substring(1, words[0].length).toLowerCase()
-
-    switch (command) {
-      case 'join':
-        words.shift()
-        var channel = words.join(' ')
-        self.emit('addChannel', channel)
-        break
-      case 'wc':
-      case 'part':
-      case 'leave':
-        self.emit('leaveChannel', self.data.activeChannel.name)
-        break
-      default:
-        console.log('Unrecognized command: ' + command + ' (in "' + commandStr + '")')
-        self.emit('sendMessage', commandStr)
-        break
-    }
-  })
+  self.on('executeCommand', command(self))
 
   self.on('addChannel', function (channelName) {
     if (channelName.charAt(0) === '#') channelName = channelName.substring(1)

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,0 +1,25 @@
+function command (self) {
+  return function (commandStr) {
+    var words = commandStr.split(' ')
+    var command = words[0].substring(1, words[0].length).toLowerCase()
+
+    switch (command) {
+      case 'join':
+        words.shift()
+        var channel = words.join(' ')
+        self.emit('addChannel', channel)
+        break
+      case 'wc':
+      case 'part':
+      case 'leave':
+        self.emit('leaveChannel', self.data.activeChannel.name)
+        break
+      default:
+        console.log('Unrecognized command: ' + command + ' (in "' + commandStr + '")')
+        self.emit('sendMessage', commandStr)
+        break
+    }
+  }
+}
+
+module.exports = command


### PR DESCRIPTION
This is a simple dropin patch that moves the command switch to its own file.  We can make it more OO if we want, but for now lets just get all of this out of app.js