### PR TITLE
Show active and idle users

### DIFF
--- a/app.js
+++ b/app.js
@@ -123,14 +123,20 @@ function App (el, currentWindow) {
       channel.messages.push(message)
     }
 
-    if (!message.anon && message.valid && !usersFound[message.username]) {
-      usersFound[message.username] = true
-      self.data.users[message.username] = {
-        avatar: message.avatar,
-        blocked: false
+    if (!message.anon && message.valid) {
+      if (!usersFound[message.username]) {
+        usersFound[message.username] = true
+        self.data.users[message.username] = {
+          avatar: message.avatar,
+          blocked: false
+        }
+
+        // Add user names to available autocompletes
+        self.views.composer.autocompletes.push(message.username)
       }
-      // Add user names to available autocompletes
-      self.views.composer.autocompletes.push(message.username)
+
+      // update last active time for user
+      self.data.users[message.username].lastActive = message.timestamp
     }
     if (!message.anon && !message.valid) {
       message.username = 'Allegedly ' + message.username

--- a/lib/elements/users.js
+++ b/lib/elements/users.js
@@ -11,12 +11,29 @@ inherits(Users, BaseElement)
 
 Users.prototype.render = function (users) {
   var self = this
+  var now = new Date().getTime()
 
-  users = Object.keys(users).sort(function (a, b) {
+  var activeUsers = []
+  var idleUsers = []
+  var sortedUsers = Object.keys(users).sort(function (a, b) {
     return a.toLowerCase().localeCompare(b.toLowerCase())
-  }).map(function (username) {
-    var user = users[username]
+  })
 
+  idleUsers = sortedUsers.filter(function (username) {
+    var user = users[username]
+    // User is "active" if they sent a message in the last 60 mins (3600000ms)
+    if (now - user.lastActive < 3600000) {
+      activeUsers.push(username)
+      return false
+    }
+    return true
+  })
+
+  idleUsers = idleUsers.map(enrichUsers)
+  activeUsers = activeUsers.map(enrichUsers)
+
+  function enrichUsers (username) {
+    var user = users[username]
     var className = user.blocked ? 'blocked' : ''
     return h('li', { className: className }, [
       h('button', {
@@ -29,11 +46,16 @@ Users.prototype.render = function (users) {
         username
       ])
     ])
-  })
+  }
+
   return [
-    h('.heading', 'Users (' + users.length + ')'),
+    h('.heading', 'Active Users (' + activeUsers.length + ')'),
     h('ul.users', [
-      users
+      activeUsers
+    ]),
+    h('.heading', 'Idle Users (' + idleUsers.length + ')'),
+    h('ul.users', [
+      idleUsers
     ])
   ]
 }


### PR DESCRIPTION
A small change to create separate lists of "active" and "idle" users. Active users are defined as a user who sent a message in the last 60 minutes.

![img](http://i.imgur.com/BXUAvts.png)
