### PR TITLE
Update package script and add package-all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 friendsdb/
 node_modules/
+pkg/
 public-keys/
 Friends.app
 *.log

--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
   },
   "devDependencies": {
     "beefy": "^2.1.5",
-    "electron-packager": "^3.1.0",
+    "electron-packager": "^4.0.2",
     "electron-prebuilt": "^0.25.1",
     "mkdirp": "^0.5.0",
     "nib": "^1.1.0",
     "node-gyp": "^1.0.3",
+    "rimraf": "^2.3.3",
+    "shelljs": "^0.4.0",
     "standard": "^3.2.1",
     "stylus": "^0.51.0",
     "watchify": "^3.2.1"
@@ -82,7 +84,8 @@
   },
   "scripts": {
     "build-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -c",
-    "package": "npm run build-css && electron-packager . Friends --icon=static/Icon.icns",
+    "package": "node pkg.js",
+    "package-all": "node pkg.js --all",
     "start": "npm run build-css && electron index.js 2>&1 | silence-chromium",
     "test": "standard",
     "watch": "npm run build-css && (npm run watch-css & electron index.js 2>&1 | silence-chromium)",

--- a/pkg.js
+++ b/pkg.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+var os = require('os')
+var pkgjson = require('./package.json')
+var path = require('path')
+var sh = require('shelljs')
+
+var appVersion = pkgjson.version
+var appName = pkgjson.name
+var electronPackager = './node_modules/.bin/electron-packager'
+var electronVersion = '0.26.0'
+var icon = 'static/Icon.icns'
+
+var ignorePaths = buildIgnorePaths()
+
+if (process.argv[2] === '--all') {
+  // build for all platforms
+  var archs = ['ia32', 'x64']
+  var platforms = ['linux', 'win32', 'darwin']
+
+  platforms.forEach(function (plat) {
+    archs.forEach(function (arch) {
+      pack(plat, arch)
+    })
+  })
+} else {
+  // build for current platform only
+  pack(os.platform(), os.arch())
+}
+
+function buildIgnorePaths () {
+  var paths = ''
+  Object.keys(pkgjson.devDependencies).forEach(function (name) {
+    paths += ' --ignore=' + path.join('node_modules', name)
+  })
+
+  // ignore the pkg directory or hilarity will ensue
+  paths += ' --ignore=pkg'
+
+  return paths
+}
+
+function pack (plat, arch) {
+  var outputPath = path.join('.', 'pkg', appVersion, plat, arch)
+
+  sh.exec('./node_modules/.bin/rimraf ' + outputPath)
+
+  // there is no darwin ia32 electron
+  if (plat === 'darwin' && arch === 'ia32') return
+
+  var cmd = electronPackager + ' . ' + appName +
+    ' --platform=' + plat +
+    ' --arch=' + arch +
+    ' --version=' + electronVersion +
+    ' --app-version' + appVersion +
+    ' --icon=' + icon +
+    ' --out=' + outputPath +
+    ' --prune' +
+    ignorePaths
+  console.log(cmd)
+  sh.exec(cmd)
+}


### PR DESCRIPTION
This updates `electron-packager` version and makes it easy to package the app for the current OS or for every OS via:
`npm run package`
`npm run package-all`
