### PR TITLE
Separate sign and verify from swarm.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ var richMessage = require('rich-message')
 var Swarm = require('./lib/swarm')
 var util = require('./lib/util')
 var command = require('./lib/command')
+var Signature = require('./lib/signature')
 
 var Channels = require('./lib/elements/channels')
 var Composer = require('./lib/elements/composer')
@@ -75,7 +76,7 @@ function App (el, currentWindow) {
     if (err) return console.error(err.message || err)
     if (verified) {
       self.data.username = username
-      swarm.username = username
+      swarm.sign = Signature.signer(username)
 
       // Re-create rich messages after we know our username, since we can now do
       // highlights correctly.
@@ -86,6 +87,8 @@ function App (el, currentWindow) {
       render()
     }
   })
+
+  swarm.verify = Signature.verify
 
   swarm.process(function (basicMessage, cb) {
     var message = richMessage(basicMessage, self.data.username)

--- a/app.js
+++ b/app.js
@@ -76,7 +76,7 @@ function App (el, currentWindow) {
     if (err) return console.error(err.message || err)
     if (verified) {
       self.data.username = username
-      swarm.sign = Signature.signer(username)
+      swarm.sign(Signature.signer(username))
 
       // Re-create rich messages after we know our username, since we can now do
       // highlights correctly.
@@ -88,7 +88,7 @@ function App (el, currentWindow) {
     }
   })
 
-  swarm.verify = Signature.verify
+  swarm.verify(Signature.verify)
 
   swarm.process(function (basicMessage, cb) {
     var message = richMessage(basicMessage, self.data.username)

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -1,0 +1,34 @@
+var fs = require('fs')
+var ghsign = require('ghsign')
+var request = require('request')
+var verifiers = {}
+
+module.exports.signer = signer
+module.exports.verify = verify
+
+ghsign = ghsign(function (username, cb) {
+  fs.readFile('./public-keys/' + username + '.keys', 'utf-8', function (_, keys) {
+    if (keys) return cb(null, keys)
+    request('https://github.com/' + username + '.keys', function (_, response) {
+      var keys = response.statusCode === 200 && response.body
+      if (!keys) return cb(new Error('Could not find public keys for ' + username))
+      fs.mkdir('./public-keys', function () {
+        fs.writeFile('./public-keys/' + username + '.keys', keys, function () {
+          cb(null, keys)
+        })
+      })
+    })
+  })
+})
+
+function signer (username) {
+  return ghsign.signer(username)
+}
+
+function verify (username, message, signature, cb) {
+  var vfy = verifiers[username]
+  if (!verifiers[username]) verifiers[username] = vfy = ghsign.verifier(username)
+  if (!vfy || !username || !signature) return cb(null, false)
+
+  vfy(message, signature, cb)
+}

--- a/lib/swarm.js
+++ b/lib/swarm.js
@@ -1,6 +1,6 @@
 var events = require('events')
 var subleveldown = require('subleveldown')
-var swarm = require('webrtc-swarm')
+var webrtcSwarm = require('webrtc-swarm')
 var signalhub = require('signalhub')
 var hyperlog = require('hyperlog')
 var through = require('through2')
@@ -12,35 +12,43 @@ var messages = protobuf(fs.readFileSync(__dirname + '/../schema.proto'))
 module.exports = createSwarm
 
 function createSwarm (db, defaultOpts) {
-  var emitter = new events.EventEmitter()
+  var swarm = new events.EventEmitter()
   var logs = {}
 
-  emitter.logs = logs
+  swarm.logs = logs
 
   var processor
   var sign
   var verify
 
-  emitter.changes = function (name) {
+  swarm.changes = function (name) {
     return logs[name] ? logs[name].changes : 0
   }
 
-  emitter.sign = function (fn) {
+  /**
+   * fn should be a function that takes the args `data, callback`.
+   * The `callback` takes the args `err, signature`.
+   */
+  swarm.sign = function (fn) {
     sign = fn
   }
 
-  emitter.verify = function (fn) {
+  /**
+   * fn should be a function that takes the args `username, signature, callback`.
+   * The `callback` is called with `err, valid` with valid being truthy if the signature was verified.
+   */
+  swarm.verify = function (fn) {
     verify = fn
   }
 
-  emitter.process = function (fn) {
+  swarm.process = function (fn) {
     processor = fn
     Object.keys(logs).forEach(function (name) {
       startProcessor(logs[name])
     })
   }
 
-  emitter.removeChannel = function (name) {
+  swarm.removeChannel = function (name) {
     var log = logs[name]
     if (!log) return
     delete logs[name]
@@ -51,7 +59,7 @@ function createSwarm (db, defaultOpts) {
     })
   }
 
-  emitter.addChannel = function (name) {
+  swarm.addChannel = function (name) {
     if (logs[name]) return
 
     var log = logs[name] = hyperlog(subleveldown(db, name))
@@ -62,7 +70,7 @@ function createSwarm (db, defaultOpts) {
       'https://beaugunderson.com/signalhub',
       'http://dev.mathiasbuus.eu:8080' // deprecated
     ])
-    var sw = swarm(hub, defaultOpts)
+    var sw = webrtcSwarm(hub, defaultOpts)
 
     log.peers = []
 
@@ -75,14 +83,14 @@ function createSwarm (db, defaultOpts) {
         if (i > -1) log.peers.splice(i, 1)
       })
 
-      emitter.emit('peer', p, name, id, stream)
+      swarm.emit('peer', p, name, id, stream)
 
       stream.on('push', function () {
-        emitter.emit('push', name)
+        swarm.emit('push', name)
       })
 
       stream.on('pull', function () {
-        emitter.emit('pull', name)
+        swarm.emit('pull', name)
       })
 
       p.pipe(stream).pipe(p)
@@ -91,10 +99,10 @@ function createSwarm (db, defaultOpts) {
     if (processor) startProcessor(log)
   }
 
-  emitter.send = function (message, cb) {
+  swarm.send = function (message, cb) {
     var addMessage = function (m, sig) {
       var ch = message.channel || 'friends'
-      emitter.addChannel(ch)
+      swarm.addChannel(ch)
       var log = logs[ch]
       log.heads(function (err, heads) {
         if (err) return cb(err)
@@ -147,5 +155,5 @@ function createSwarm (db, defaultOpts) {
     })
   }
 
-  return emitter
+  return swarm
 }

--- a/lib/swarm.js
+++ b/lib/swarm.js
@@ -3,32 +3,13 @@ var subleveldown = require('subleveldown')
 var swarm = require('webrtc-swarm')
 var signalhub = require('signalhub')
 var hyperlog = require('hyperlog')
-var ghsign = require('ghsign')
 var through = require('through2')
 var protobuf = require('protocol-buffers')
 var fs = require('fs')
-var request = require('request')
 
 var messages = protobuf(fs.readFileSync(__dirname + '/../schema.proto'))
 
 module.exports = createSwarm
-
-ghsign = ghsign(function (username, cb) {
-  fs.readFile('./public-keys/' + username + '.keys', 'utf-8', function (_, keys) {
-    if (keys) return cb(null, keys)
-    request('https://github.com/' + username + '.keys', function (_, response) {
-      var keys = response.statusCode === 200 && response.body
-      if (!keys) return cb(new Error('Could not find public keys for ' + username))
-      fs.mkdir('./public-keys', function () {
-        fs.writeFile('./public-keys/' + username + '.keys', keys, function () {
-          cb(null, keys)
-        })
-      })
-    })
-  })
-})
-
-var verifiers = {}
 
 function createSwarm (db, defaultOpts) {
   var emitter = new events.EventEmitter()
@@ -36,11 +17,20 @@ function createSwarm (db, defaultOpts) {
 
   emitter.logs = logs
 
-  var sign
   var processor
+  var sign
+  var verify
 
   emitter.changes = function (name) {
     return logs[name] ? logs[name].changes : 0
+  }
+
+  emitter.sign = function (fn) {
+    sign = fn
+  }
+
+  emitter.verify = function (fn) {
+    verify = fn
   }
 
   emitter.process = function (fn) {
@@ -102,10 +92,6 @@ function createSwarm (db, defaultOpts) {
   }
 
   emitter.send = function (message, cb) {
-    if (!sign && emitter.username) {
-      sign = ghsign.signer(emitter.username)
-    }
-
     var addMessage = function (m, sig) {
       var ch = message.channel || 'friends'
       emitter.addChannel(ch)
@@ -144,14 +130,11 @@ function createSwarm (db, defaultOpts) {
         var val = messages.SignedMessage.decode(data.value)
         var m = messages.Message.decode(val.message)
         var u = m.username
-        var verify = verifiers[u]
-
-        if (u && !verifiers[u]) verifiers[u] = verify = ghsign.verifier(u)
 
         m.change = data.change
 
-        if (verify && val.signature) {
-          verify(val.message, val.signature, function (_, valid) {
+        if (verify) {
+          verify(u, val.message, val.signature, function (_, valid) {
             m.valid = !!valid
             processor(m, cb)
           })


### PR DESCRIPTION
This PR moves the sign and verify logic out of `swarm.js` and into `lib/signature.js`. 

There are a couple reasons for this:
1. The current sign/verify logic is dependent on the filesystem and will not work in a browser. This separation will allow for an alternative way to sign/verify messages in-browser.
2. There is a need to push `swarm.js` into its own module so its reusable by peerbot/friends-irc/other bots. Abstracting signature will help to keep this future module focused. Also bots probably don't need to sign/verify.

Please yell at me if this is outrageous. :grin: 