### PR TITLE
make user menu items more explicit

### DIFF
--- a/lib/elements/users.js
+++ b/lib/elements/users.js
@@ -62,20 +62,20 @@ Users.prototype.render = function (users) {
 
   // Build user menu
   this.userMenu.shown = !!this.showUserMenuFor
-  var ignoreLabel = 'mute user'
-  if (users[this.showUserMenuFor] && users[this.showUserMenuFor].blocked) ignoreLabel = 'unmute user'
+  var ignoreLabel = 'mute '
+  if (users[this.showUserMenuFor] && users[this.showUserMenuFor].blocked) ignoreLabel = 'unmute '
   this.userMenu.render(
     h('ul', [
       h('li', h('a', {
         href: 'https://github.com/' + this.showUserMenuFor,
         target: '_blank'
-      }, 'github.com/' + this.showUserMenuFor)),
+      }, 'open github.com/' + this.showUserMenuFor)),
       h('li', h('button', {
         onclick: function (e) {
           e.preventDefault()
           self.send('toggleBlockUser', self.showUserMenuFor)
         }
-      }, ignoreLabel))
+      }, ignoreLabel + this.showUserMenuFor))
     ])
   )
 


### PR DESCRIPTION
Hey @shama what do you think?

![clipboard02](https://cloud.githubusercontent.com/assets/360233/7695137/87962ece-fdb0-11e4-9264-3c4a67307830.jpg)

Totally subjective, but I like the clarity of "mute Flet" vs "mute user", especially since there is no visual cue to show which user was right-clicked.

Also adding a verb in front of the github URL clarifies what will happen if that item is selected.

Just some thoughts, I'm not a UXpert here :)