### PR TITLE
adhere to padded-blocks

### DIFF
--- a/lib/elements/input-prompt.js
+++ b/lib/elements/input-prompt.js
@@ -38,7 +38,6 @@ InputPrompt.prototype.render = function () {
         }
       })
     ])
-
   } else {
     view = h('button', {
       onclick: function (e) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.