### PR TITLE
more explicit setup / installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm i github-current-user -g
 $ DEBUG=* github-current-user
 ```
 
-and then report an [issue](https://github.com/noffle/friends/issues).
+and then report an [issue](https://github.com/moose-team/friends/issues).
 
 **Note**: DSA keys are not supported. You should switch to RSA anyway for security reasons.
 

--- a/README.md
+++ b/README.md
@@ -20,34 +20,40 @@ fixing things :)
 
 See [our site](http://moose-team.github.io/friends/) or the `gh-pages` branch.
 
+## Installation
+
 ## Logging in
 
-You need a working git + github configuration
+Friends currently uses your git + github configuration.
 
-- have a publicly listed github email (e.g. shows up on your github account)
-- if you dont wanna do that then do `git config --global user.username yourusername`
+If you don't already have a public key on GitHub and its private key on your
+machine, you'll need to [set that up
+first](https://help.github.com/articles/generating-ssh-keys/). Make sure your
+github username is also set, using `git config --global user.username
+yourusername`.
 
-When you launch the app it should "just work" now if you have git setup correctly :)
-
-If it doesnt work, do this to get debug information:
+If this doesn't work, do this to get debug information:
 
 ```
 $ npm i github-current-user -g
 $ DEBUG=* github-current-user
 ```
 
-Note: DSA keys are not supported. You should switch to RSA anyway for security reasons.
+and then report an [issue](https://github.com/noffle/friends/issues).
+
+**Note**: DSA keys are not supported. You should switch to RSA anyway for security reasons.
 
 If it can't verify you, try doing `ssh-add ~/.ssh/id_rsa`. Your key should show up when you run `ssh-add -l`.
 
-## Building
+## Building & Running
 
 You'll need the newest io.js and npm (`>= 1.8.1`, `>= 2.8.3`)
 
-* `npm install`
+* `git clone https://github.com/moose-team/friends` to get the sources
+* `npm install` to install dependencies
 * `npm run rebuild-leveldb` to compile leveldown for [electron](http://electron.atom.io/). you will have to modify the command in package.json if you are not on a 64-bit architecture
-* `npm start` to run in electron
-* `npm run package` to build distributable.
+* `npm start` to run
+* `npm run package` to build a distributable app
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,47 @@ fixing things :)
 
 See [our site](http://moose-team.github.io/friends/) or the `gh-pages` branch.
 
-## Installation
+## Install
 
-### Logging in
+### Prerequisites
+
+You'll need the newest [io.js](https://iojs.org) and npm (`>= 1.8.1`, `>= 2.8.3`)
+
+### Build
+
+Clone the sources locally:
+
+```sh
+$ git clone https://github.com/moose-team/friends
+
+$ cd friends
+```
+
+Install project dependencies:
+
+```sh
+$ npm install
+```
+
+Compile leveldown for [electron](http://electron.atom.io/):
+
+```sh
+$ npm run rebuild-leveldb
+```
+
+If you are not on 64-bit architecture, you will have to modify the command in
+package.json:
+
+```
+"rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.34.2 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
+```
+
+to use `--arch=ia32`.
+
+
+## Usage
+
+### GitHub Login
 
 Friends currently uses your git + github configuration.
 
@@ -45,15 +83,11 @@ and then report an [issue](https://github.com/moose-team/friends/issues).
 
 If it can't verify you, try doing `ssh-add ~/.ssh/id_rsa`. Your key should show up when you run `ssh-add -l`.
 
-### Building & Running
+### Run
 
-You'll need the newest io.js and npm (`>= 1.8.1`, `>= 2.8.3`)
+To run from the command line, execute `npm start`.
 
-1. `git clone https://github.com/moose-team/friends` to get the sources
-2. `npm install` to install dependencies
-3. `npm run rebuild-leveldb` to compile leveldown for [electron](http://electron.atom.io/). you will have to modify the command in package.json if you are not on a 64-bit architecture
-4. `npm start` to run
-5. `npm run package` to build a distributable app, if you'd like
+To create a distributable app, run `npm run package`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ If it can't verify you, try doing `ssh-add ~/.ssh/id_rsa`. Your key should show 
 
 You'll need the newest io.js and npm (`>= 1.8.1`, `>= 2.8.3`)
 
-* `git clone https://github.com/moose-team/friends` to get the sources
-* `npm install` to install dependencies
-* `npm run rebuild-leveldb` to compile leveldown for [electron](http://electron.atom.io/). you will have to modify the command in package.json if you are not on a 64-bit architecture
-* `npm start` to run
-* `npm run package` to build a distributable app
+1. `git clone https://github.com/moose-team/friends` to get the sources
+2. `npm install` to install dependencies
+3. `npm run rebuild-leveldb` to compile leveldown for [electron](http://electron.atom.io/). you will have to modify the command in package.json if you are not on a 64-bit architecture
+4. `npm start` to run
+5. `npm run package` to build a distributable app, if you'd like
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [our site](http://moose-team.github.io/friends/) or the `gh-pages` branch.
 
 ## Installation
 
-## Logging in
+### Logging in
 
 Friends currently uses your git + github configuration.
 
@@ -45,7 +45,7 @@ and then report an [issue](https://github.com/noffle/friends/issues).
 
 If it can't verify you, try doing `ssh-add ~/.ssh/id_rsa`. Your key should show up when you run `ssh-add -l`.
 
-## Building & Running
+### Building & Running
 
 You'll need the newest io.js and npm (`>= 1.8.1`, `>= 2.8.3`)
 


### PR DESCRIPTION
The current README has headings for `Logging In` and `Building`, and doesn't make the installation/running instructions too explicit for first-time readers (as per #147).

#146 is a good next step for simplifying this process.