### PR TITLE
use electron-prebuilt@^0.36.4, node >= 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [our site](http://moose-team.github.io/friends/) or the `gh-pages` branch.
 
 ### Prerequisites
 
-You'll need the newest [io.js](https://iojs.org) and npm (`>= 1.8.1`, `>= 2.8.3`)
+You'll need the newest [node.js](https://nodejs.org) (`>= 4`) and npm (`>= 2.8.3`).
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are not on 64-bit architecture, you will have to modify the command in
 package.json:
 
 ```
-"rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.34.2 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
+"rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=$(../../version.js) --arch=x64 --dist-url=https://atom.io/download/atom-shell"
 ```
 
 to use `--arch=ia32`.

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function appReady () {
     height: 600,
     title: APP_NAME
   })
-  mainWindow.loadUrl(INDEX)
+  mainWindow.loadURL(INDEX)
 
   mainWindow.on('closed', function () {
     mainWindow = null

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "github-current-user": false,
     "leveldown": "level-js"
   },
+  "browserify": {
+    "transforms": [
+      "brfs"
+    ]
+  },
   "bugs": {
     "url": "https://github.com/moose-team/friends/issues"
   },
@@ -49,7 +54,7 @@
     "beefy": "^2.1.5",
     "brfs": "^1.4.1",
     "electron-packager": "^5.0.2",
-    "electron-prebuilt": "^0.34.2",
+    "electron-prebuilt": "^0.36.4",
     "mkdirp": "^0.5.0",
     "nib": "^1.1.0",
     "node-gyp": "^2.0.2",
@@ -59,21 +64,25 @@
     "stylus": "^0.52.0",
     "watchify": "^3.2.1"
   },
+  "engines": {
+    "node": ">=4",
+    "npm": ">=2.8.3"
+  },
   "homepage": "https://github.com/moose-team/friends",
   "keywords": [
-    "peer-to-peer",
-    "mad science",
     "chat",
-    "friends",
-    "p2p",
-    "discussion",
     "communication",
-    "team chat",
-    "replication",
     "crypto",
-    "webrtc",
+    "discussion",
+    "friends",
     "irc",
-    "slack"
+    "mad science",
+    "p2p",
+    "peer-to-peer",
+    "replication",
+    "slack",
+    "team chat",
+    "webrtc"
   ],
   "license": "MIT",
   "main": "index.js",
@@ -81,20 +90,15 @@
     "type": "git",
     "url": "https://github.com/moose-team/friends.git"
   },
-  "browserify": {
-    "transforms": [
-      "brfs"
-    ]
-  },
   "scripts": {
     "build-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -c",
     "package": "node pkg.js",
     "package-all": "node pkg.js --all",
+    "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.34.2 --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "npm run build-css && electron index.js 2>&1 | silence-chromium",
     "test": "standard",
     "watch": "npm run build-css && (npm run watch-css & electron index.js 2>&1 | silence-chromium)",
     "watch-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -w",
-    "web": "beefy web.js:bundle.js",
-    "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.34.2 --arch=x64 --dist-url=https://atom.io/download/atom-shell"
+    "web": "beefy web.js:bundle.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "build-css": "mkdirp dist && stylus -u nib css/app.styl -o dist/ -c",
     "package": "node pkg.js",
     "package-all": "node pkg.js --all",
-    "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=0.34.2 --arch=x64 --dist-url=https://atom.io/download/atom-shell",
+    "rebuild-leveldb": "cd node_modules/leveldown && set HOME=~/.electron-gyp && node-gyp rebuild --target=$(../../version.js) --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "npm run build-css && electron index.js 2>&1 | silence-chromium",
     "test": "standard",
     "watch": "npm run build-css && (npm run watch-css & electron index.js 2>&1 | silence-chromium)",

--- a/pkg.js
+++ b/pkg.js
@@ -4,11 +4,11 @@ var os = require('os')
 var pkgjson = require('./package.json')
 var path = require('path')
 var sh = require('shelljs')
+var electronVersion = require('./version')
 
 var appVersion = pkgjson.version
 var appName = pkgjson.name
 var electronPackager = './node_modules/.bin/electron-packager'
-var electronVersion = '0.26.0'
 var icon = 'static/Icon.icns'
 
 if (process.argv[2] === '--all') {

--- a/version.js
+++ b/version.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var pkg = require('./package.json')
+var version = pkg.devDependencies['electron-prebuilt'].replace('^', '')
+
+if (require.main === module) console.log(version)
+
+module.exports = version


### PR DESCRIPTION
Hi friends!

I encountered a show-stopping error when running `npm start` with newer node (`>= 4`). Saw this in electron JS console.

```
Uncaught Error: Module version mismatch. Expected 46, got 47.
```

Using latest electron-prebuilt and node >= 4 seemed to take care of the issue.

I bumped electron-prebuilt to latest and set engines in package.json to:

```json
"engines": {
  "node": ">=4",
  "npm": ">=2.8.3"
}
```

Adjusted docs to reflect the change and ran [fixpack](https://github.com/henrikjoreteg/fixpack) for good measure.

Getting things in order to take a crack at another sprint for #151.

@moose-team/owners please take a look and let me know if it's alright to forge ahead.