### PR TITLE
fix get.concat parameter order (changed in simple-get@2)

### DIFF
--- a/lib/signature.js
+++ b/lib/signature.js
@@ -10,7 +10,7 @@ if (!process.browser) {
   ghsign = ghsign(function (username, cb) {
     fs.readFile('./public-keys/' + username + '.keys', 'utf-8', function (_, keys) {
       if (keys) return cb(null, keys)
-      get.concat('https://github.com/' + username + '.keys', function (_, body, res) {
+      get.concat('https://github.com/' + username + '.keys', function (_, res, body) {
         var keys = res.statusCode === 200 && body
         if (!keys) return cb(new Error('Could not find public keys for ' + username))
         fs.mkdir('./public-keys', function () {


### PR DESCRIPTION
broken by fba99293fd50610190df3c385a1e67ed71e0df28

should have noticed https://github.com/feross/simple-get/commit/4b61c892d4d603dfbc980329e68e0f3f940e1076

:bug: :facepunch: 