### PR TITLE
centralize config, store db & keys in config path

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,13 +16,13 @@ var leveldown = require('leveldown') // browser: level-js
 var levelup = require('levelup')
 var patch = require('virtual-dom/patch')
 var subleveldown = require('subleveldown')
-
 var richMessage = require('rich-message')
 var Swarm = require('friends-swarm')
+
+var config = require('../config')
 var util = require('./lib/util')
 var command = require('./lib/command')
 var Signature = require('./lib/signature')
-
 var Channels = require('./lib/elements/channels')
 var Composer = require('./lib/elements/composer')
 var Messages = require('./lib/elements/messages')
@@ -37,7 +37,7 @@ function App (el, currentWindow) {
   self._notifications = 0
   self.currentWindow = currentWindow
 
-  var db = levelup('./friendsdb', {db: leveldown})
+  var db = levelup(config.DB_PATH, {db: leveldown})
 
   db.channels = subleveldown(db, 'channels', {valueEncoding: 'json'})
   db.aliases = subleveldown(db, 'aliases', {valueEncoding: 'json'})

--- a/config.js
+++ b/config.js
@@ -1,6 +1,5 @@
 var applicationConfigPath = require('application-config-path')
 var path = require('path')
-var fs = require('fs')
 
 var CONFIG_PATH = applicationConfigPath('Friends')
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,15 @@
+var applicationConfigPath = require('application-config-path')
+var path = require('path')
+var fs = require('fs')
+
+var CONFIG_PATH = applicationConfigPath('Friends')
+
+module.exports = {
+  APP_NAME: 'Friends',
+
+  CONFIG_PATH: CONFIG_PATH,
+  DB_PATH: path.join(CONFIG_PATH, 'friendsdb'),
+  KEYS_PATH: path.join(CONFIG_PATH, 'public-keys'),
+
+  INDEX: 'file://' + path.join(__dirname, 'index.html')
+}

--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
 var BrowserWindow = require('browser-window')
-var path = require('path')
-
-var APP_NAME = 'Friends'
-var INDEX = 'file://' + path.join(__dirname, 'index.html')
-
+var config = require('../config')
 var app = require('app')
+
 app.on('ready', appReady)
 
 var mainWindow
@@ -13,9 +10,10 @@ function appReady () {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
-    title: APP_NAME
+    title: config.APP_NAME
   })
-  mainWindow.loadURL(INDEX)
+
+  mainWindow.loadURL(config.INDEX)
 
   mainWindow.on('closed', function () {
     mainWindow = null

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -1,6 +1,9 @@
 var fs = require('fs')
 var ghsign = require('ghsign')
 var get = require('simple-get')
+var mkdirp = require('mkdirp')
+var path = require('path')
+var config = require('../config')
 var verifiers = {}
 
 module.exports.signer = signer
@@ -8,13 +11,14 @@ module.exports.verify = verify
 
 if (!process.browser) {
   ghsign = ghsign(function (username, cb) {
-    fs.readFile('./public-keys/' + username + '.keys', 'utf-8', function (_, keys) {
+    var userKeysPath = path.join(config.KEYS_PATH, username + '.keys')
+    fs.readFile(userKeysPath, 'utf-8', function (_, keys) {
       if (keys) return cb(null, keys)
       get.concat('https://github.com/' + username + '.keys', function (_, res, body) {
         var keys = res.statusCode === 200 && body
         if (!keys) return cb(new Error('Could not find public keys for ' + username))
-        fs.mkdir('./public-keys', function () {
-          fs.writeFile('./public-keys/' + username + '.keys', keys, function () {
+        mkdirp(config.KEYS_PATH, function () {
+          fs.writeFile(userKeysPath, keys, function () {
             cb(null, keys.toString())
           })
         })

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/moose-team/friends/issues"
   },
   "dependencies": {
+    "application-config-path": "^0.1.0",
     "cat-names": "^1.0.2",
     "ctype": "^0.5.4",
     "delegate-dom": "0.0.1",
@@ -41,6 +42,7 @@
     "leveldown": "^1.4.1",
     "levelup": "^1.2.1",
     "lodash.uniq": "^4.2.0",
+    "mkdirp": "^0.5.1",
     "modal-element": "^1.0.0",
     "moment": "^2.12.0",
     "rich-message": "^1.0.0",
@@ -55,7 +57,6 @@
     "brfs": "^1.4.1",
     "electron-packager": "^5.0.2",
     "electron-prebuilt": "0.36.10",
-    "mkdirp": "^0.5.0",
     "nib": "^1.1.0",
     "node-gyp": "^2.0.2",
     "rimraf": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node-gyp": "^2.0.2",
     "rimraf": "^2.3.3",
     "shelljs": "^0.4.0",
-    "standard": "^5.1.1",
+    "standard": "^6.0.8",
     "stylus": "^0.52.0",
     "watchify": "^3.2.1"
   },

--- a/pkg.js
+++ b/pkg.js
@@ -42,8 +42,8 @@ function pack (plat, arch) {
     `--app-version=${appVersion} ` +
     `--icon=${icon} ` +
     `--out=${outputPath} ` +
-    `--prune ` +
-    `--ignore=pkg` // ignore the pkg directory or hilarity will ensue
+    '--prune ' +
+    '--ignore=pkg' // ignore the pkg directory or hilarity will ensue
 
   console.log(`${cmd1}\n${cmd2}`)
 


### PR DESCRIPTION
using `application-config-path@^0.1.0` for OS-friendly config path

note this means if you want to keep history you need to copy `friendsdb` and `public-keys` from the project directory to the application config path, which will be...

Platform | Location
--- | ---
OS X | `~/Library/Application Support/Friends/config.json`
Linux (XDG) | `$XDG_CONFIG_HOME/Friends/config.json`
Linux (Legacy) | `~/.config/Friends/config.json`
Windows (> Vista) | `%LOCALAPPDATA%/Friends/config.json`
Windows (XP, 2000) | `%USERPROFILE%/Local Settings/Application Data/Friends/config.json`